### PR TITLE
Add setting_version required for Cura 2.6

### DIFF
--- a/cura-resources/variants/Mark2_for_Ultimaker2_0.25.inst.cfg
+++ b/cura-resources/variants/Mark2_for_Ultimaker2_0.25.inst.cfg
@@ -6,6 +6,7 @@ definition = Mark2_for_Ultimaker2
 [metadata]
 author = Ultimaker
 type = variant
+setting_version = 1
 
 [values]
 machine_nozzle_size = 0.25

--- a/cura-resources/variants/Mark2_for_Ultimaker2_0.4.inst.cfg
+++ b/cura-resources/variants/Mark2_for_Ultimaker2_0.4.inst.cfg
@@ -6,6 +6,7 @@ definition = Mark2_for_Ultimaker2
 [metadata]
 author = Ultimaker
 type = variant
+setting_version = 1
 
 [values]
 machine_nozzle_size = 0.4

--- a/cura-resources/variants/Mark2_for_Ultimaker2_0.6.inst.cfg
+++ b/cura-resources/variants/Mark2_for_Ultimaker2_0.6.inst.cfg
@@ -6,6 +6,7 @@ definition = Mark2_for_Ultimaker2
 [metadata]
 author = Ultimaker
 type = variant
+setting_version = 1
 
 [values]
 machine_nozzle_size = 0.6

--- a/cura-resources/variants/Mark2_for_Ultimaker2_0.8.inst.cfg
+++ b/cura-resources/variants/Mark2_for_Ultimaker2_0.8.inst.cfg
@@ -6,6 +6,7 @@ definition = Mark2_for_Ultimaker2
 [metadata]
 author = Ultimaker
 type = variant
+setting_version = 1
 
 [values]
 machine_nozzle_size = 0.8


### PR DESCRIPTION
This PR adds the setting_version that is required for Cura 2.6 and newer. I think Cura 2.5 and before will just ignore this.